### PR TITLE
Add option to open menu in available full height

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -22,6 +22,10 @@
       <label>Shows an indicator underneath the launcher's icon when the launcher is opened.</label>
       <default>true</default>
     </entry>
+    <entry name="fullHeight" type="Bool">
+      <label>Fill the full screen height with the launcher.</label>
+      <default>false</default>
+    </entry>
     <entry name="indicatorColor" type="Color">
       <label>Color of the indicator.</label>
       <default>#2164C9</default>

--- a/contents/ui/ConfigGeneral.qml
+++ b/contents/ui/ConfigGeneral.qml
@@ -43,6 +43,7 @@ Kirigami.FormLayout {
     property bool cfg_useCustomButtonImage: plasmoid.configuration.useCustomButtonImage
     property string cfg_customButtonImage: plasmoid.configuration.customButtonImage
     property bool cfg_activationIndicator: plasmoid.configuration.activationIndicator
+    property bool cfg_fullHeight: plasmoid.configuration.fullHeight
     property color cfg_indicatorColor: plasmoid.configuration.indicatorColor
     property bool cfg_enableGreeting: plasmoid.configuration.indicatorColor
     property alias cfg_defaultPage: defaultPage.currentIndex
@@ -213,6 +214,13 @@ Kirigami.FormLayout {
         i18n("Screen Center"),
         ]
         onCurrentIndexChanged: {
+          if (currentIndex == 0) {
+            fullHeight.visible = true
+            floating.enabled = false
+          } else {
+              fullHeight.visible = false
+          }
+
           if (currentIndex == 2) {
             floating.enabled = false
             floating.checked = true
@@ -220,6 +228,15 @@ Kirigami.FormLayout {
             floating.enabled = true
           }
         }
+    }
+    CheckBox {
+      id: fullHeight
+      text: i18n("Full height")
+      onCheckedChanged: {
+        plasmoid.configuration.fullHeight = checked
+        cfg_fullHeight = checked
+        floating.visible = !checked
+      }
     }
     CheckBox {
       id: floating

--- a/contents/ui/MenuRepresentation.qml
+++ b/contents/ui/MenuRepresentation.qml
@@ -22,6 +22,7 @@
 
 import QtQuick 2.12
 import QtQuick.Layouts 1.12
+import QtQuick.Window 2.2
 import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 3.0 as PlasmaComponents
 
@@ -132,7 +133,7 @@ PlasmaCore.Dialog {
         id: fs
         focus: true
         Layout.minimumWidth: 515 * PlasmaCore.Units.devicePixelRatio
-        Layout.minimumHeight: 600 * PlasmaCore.Units.devicePixelRatio
+        Layout.minimumHeight: (plasmoid.configuration.fullHeight ? Screen.desktopAvailableHeight : 600) * PlasmaCore.Units.devicePixelRatio
         Layout.maximumWidth: Layout.minimumWidth
         Layout.maximumHeight: Layout.minimumHeight
 


### PR DESCRIPTION
Add an simple option to display the menu in the full screen height.
I added some rules to only display this option in the "default" launcher position and to disable floating when this option is enabled.
As I'm not an expert in QML, somethings may not be developed in the best way.