### PR TITLE
Remove stay on top hint flag

### DIFF
--- a/contents/ui/FloatingAvatar.qml
+++ b/contents/ui/FloatingAvatar.qml
@@ -28,7 +28,6 @@ PlasmaCore.Dialog { //cosmic background noise is less random than the placement 
   property int avatarWidth
   property bool isTop: false
 
-  flags: Qt.WindowStaysOnTopHint
   type: "Notification"
 
   x: root.x + root.width / 2 - width / 2


### PR DESCRIPTION
Addresses issue #19 

Before:
![image](https://github.com/SnoutBug/mmcklauncher/assets/30195425/bbb764db-1ac6-4cd0-b29f-f48cda32ac67)

After:
![image](https://github.com/SnoutBug/mmcklauncher/assets/30195425/bfc9cf7e-5c05-49b1-bde3-a32b6bcc5dde)

Not sure why exactly this fixes the issue. After looking at [Andromeda](https://github.com/EliverLara/AndromedaLauncher/blob/main/contents/ui/FloatingAvatar.qml) it seemed that it didn't have that flag and after removing it the issue was fixed. 

For some reason on my system when I use the created from main I have only a fade-in animation and not a slider up animation for the whole pasmoid.